### PR TITLE
chore(renovate): enable automerge for minor/patch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,13 @@
   "extends": [
     "config:recommended",
     "helpers:pinGitHubActionDigests"
-  ]
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ],
+  "platformAutomerge": true,
+  "automergeStrategy": "squash"
 }


### PR DESCRIPTION
Renovate auto-merge 検証用。minor/patch を automerge:true + platformAutomerge:true + automergeStrategy:squash。major は手動承認のまま。